### PR TITLE
Bg fix dashboard ui 161697863

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+UI/static/img/Admin Dashboard_files/

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -14,7 +14,7 @@
                 <div class="logo"><img src="static/img/logo.svg" alt=""></div>
                 <div class="name"><span>SendIT</span></div>
             </div>
-            <div class="new-order"><span><img src="static/img/add.svg" alt=""></span> <span class="txt">New Order</span>
+            <div id="new-order"><a class="create-order"href="create-order.html"><span><img src="static/img/add.svg" alt=""></span><a class="create-order"href="create-order.html"><span class="txt">New Order</span></a>
             </div>
             <div class="option" id="all">
                 <span class="icon"><img src="static/img/choices.svg" alt=""></span>

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -51,8 +51,9 @@
                 <div id="title">
                     <div class="heading"><span>All your parcel Orders</span></div>
                     <div class="order-statistics">
-                        <div id="delivered-orders"><span id="dlvd">Delivered </span><span> 46</span></div>
-                        <div id="undelivered-orders"><span id="trst">In Transit </span><span>5</span></div>
+                        <div id="delivered-orders"><span class="delivered stat" id="dlvd">Delivered </span><span> 46</span></div>
+                        <div id="undelivered-orders"><span class="in-transit stat" id="trst">In Transit </span><span>5</span></div>
+                        <div id="cancelled-orders"><span class="canceled stat" id="cncld">Canceled </span><span>8</span></div>
                     </div>
                     <div class="titles">
                         <span class="order-no">Order #</span>

--- a/UI/static/css/style.css
+++ b/UI/static/css/style.css
@@ -303,27 +303,34 @@ form{
 .no{
     padding-top: 3px
 }
-.new-order{
-    background-color: #ffffff;
+#new-order{
+    background-color: #fff;
     color: rgb(9, 6, 34);
     margin: 5% 10% 0 4%;
     border-radius: 5px;
     display: grid;
     grid-template-columns: 1fr 3fr;
-    background-color: #fff;
     cursor: pointer;
-    width: 78%;
-    
+    width: 78%;    
 }
-.new-order img{
+
+#new-order:hover{
+    background-color: rgb(242, 241, 248);
+}
+#new-order img{
     height: 25px;
     padding-left: 3px;
     padding-top: 4px;
 }
 
-.new-order .txt{
-    margin-top: 4px;
-    font-size: 17px;
+.create-order{
+    text-decoration: none;
+}
+
+#new-order .txt{    
+    font-size: 19px;
+    font-weight: 300;
+    color: rgb(9, 6, 34);
 }
 
 .dash-cont{

--- a/UI/static/css/style.css
+++ b/UI/static/css/style.css
@@ -387,6 +387,8 @@ form{
     grid-template-columns: 1fr;
     grid-row-gap: 1px;
     padding: 0 2px 1px 2px ;
+    background-color: #fff;
+    border-radius: 5px;
     box-shadow: 0px 3px 5px rgba(100, 100, 100, 0.49);
     
 

--- a/UI/static/css/style.css
+++ b/UI/static/css/style.css
@@ -496,7 +496,7 @@ form{
 .save-btn{
     margin-left: 10%;
     background-color: rgb(30, 170, 72);
-    padding: 14px;
+    padding: 10px;
     border-radius: 5px;
     color: #fff;
     cursor: pointer;
@@ -582,5 +582,9 @@ form{
 
 .edit-input-label{
      margin-top: 5%;
+}
+
+.edit-mode{
+    margin-left: 10%;
 }
 

--- a/UI/static/css/style.css
+++ b/UI/static/css/style.css
@@ -513,18 +513,18 @@ form{
     display: none;
 }
 
-.cancel-btn img{
-    height: 100%
-
-}
 
 .cancel-btn{
-    font-size: 20px;
     float: right;
-    font-weight: bold;
-    justify-content: end;
-    padding-right: 8px;
     display: none;
+    color: red;
+    border: 1px solid red;
+    font-size: 10px;
+}
+
+.cancel-btn:hover{
+    background-color: red;
+    color: #fff;
 }
 
 .statuses{
@@ -561,6 +561,11 @@ form{
     display: none; 
 }
 
+.edit-btn:hover{
+    background-color: blue;
+    color: #fff;
+}
+
 .action-btn{
     justify-self: end;
     padding-right: 4px;
@@ -571,8 +576,7 @@ form{
 }
 
 .action-btn:hover{
-    font-weight: bolder;
-    font-size: 16px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19); 
     
 }
 

--- a/UI/static/css/style.css
+++ b/UI/static/css/style.css
@@ -568,9 +568,10 @@ form{
     display: none; 
 }
 
-.edit-btn:hover{
+.edit-btn:hover, .edit-button:hover{
     background-color: blue;
     color: #fff;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19); 
 }
 
 .action-btn{
@@ -579,7 +580,8 @@ form{
     cursor: pointer;
     display: none;
     padding: 4px;
-    border-radius: 4px
+    border-radius: 4px;
+    
 }
 
 .action-btn:hover{
@@ -595,3 +597,15 @@ form{
     margin-left: 10%;
 }
 
+.edit-button{
+    color: blue;
+    border: 1px solid blue;
+    float: right;
+    padding: 2px 6px 2px 6px;
+    border-radius: 4px;
+    font-weight: 100;
+    cursor: pointer;
+    
+
+    
+}

--- a/UI/static/img/Admin Dashboard.html
+++ b/UI/static/img/Admin Dashboard.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="Admin%20Dashboard_files/style.css">
+</head>
+
+<body>
+    <div class="dashboard" id="admin">
+        <div class="side-panel">
+            <div class="brand">
+                <div class="logo"><img src="Admin%20Dashboard_files/logo.svg" alt=""></div>
+                <div class="name"><span>SendIT</span></div>
+            </div>
+            <div class="option" id="admin-all">
+                <span class="icon"><img src="Admin%20Dashboard_files/choices.svg" alt=""></span>
+                <span class="opt-name">All Placed orders </span>
+                <span class="no">4</span>
+            </div>
+            <div class="option" id="admin-transit">
+                <span class="icon"><img src="Admin%20Dashboard_files/delivery-truck.svg" alt=""></span>
+                <span class="opt-name">Orders in transit</span>
+                <span class="no">5</span>
+            </div>
+            <div class="option" id="admin-deliver">
+                <span class="icon"><img src="Admin%20Dashboard_files/shipped.svg" alt=""></span>
+                <span class="opt-name">Delivered Orders</span>
+                <span class="no">2</span>
+            </div>
+            <div class="option" id="admin-cancel">
+                <span class="icon"><img src="Admin%20Dashboard_files/canceled.svg" alt=""></span>
+                <span class="opt-name">Canceled orders</span>
+                <span class="no">4</span>
+            </div>
+            <div class="option" id="admin-notification">
+                <span class="icon"><img src="Admin%20Dashboard_files/notification.svg" alt=""></span>
+                <span class="opt-name">Notifications </span>
+                <span class="no">4</span>
+            </div>
+
+        </div>
+        <div class="dash-cont">
+            <header>
+                <div class="user"><span class="acc-name">Admin</span><span class="init">A</span></div>
+            </header>
+            <div class="cont">
+                <div id="title">
+                    <div class="heading"><span>All Placed Orders</span></div>
+                    <div class="order-statistics">
+                        <div id="delivered-orders"><span id="dlvd" class="delivered stat">Delivered </span><span> 46</span></div>
+                        <div id="undelivered-orders"><span id="trst" class="in-transit stat">In Transit </span><span>5</span></div>
+                        <div id="undelivered-orders"><span id="cncld" class="canceled stat">Canceled </span><span>5</span></div>
+                    </div>
+                    <div class="titles">
+                        <span class="order-no">Order #</span>
+                        <span>Pickup Address</span>
+                        <span>Destination Address</span>
+                        <span>Weight</span>
+                        <span>Price</span>
+                        <span>Status</span>
+                    </div>
+                </div>
+                <div id="all-orders"><div class="order"><span class="order-id">127</span>
+        <span class="pickup">5 6535 453</span>
+        <span class="Destination">8 5465 742</span>
+        <span><span class="weight">6</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1200</span></span>
+        <span class="statuses"><span class="status canceled">Canceled</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">132</span>
+        <span class="pickup">4 5435 324</span>
+        <span class="Destination">6 5356 353</span>
+        <span><span class="weight">3</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 600</span></span>
+        <span class="statuses"><span class="status delivered">Delivered</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">133</span>
+        <span class="pickup">5 6535 453</span>
+        <span class="Destination">8 5465 742</span>
+        <span><span class="weight">6</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1200</span></span>
+        <span class="statuses"><span class="status canceled">Canceled</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">249</span>
+        <span class="pickup">4 5345 343</span>
+        <span class="Destination">4 5343 343</span>
+        <span><span class="weight">5</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1000</span></span>
+        <span class="statuses"><span class="status in-transit">In-transit</span><span class="action-btn edit-btn" style="display: grid;">Edit</span></span></div><div class="order"><span class="order-id">301</span>
+        <span class="pickup">4 5345 343</span>
+        <span class="Destination">4 5343 343</span>
+        <span><span class="weight">5</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1000</span></span>
+        <span class="statuses"><span class="status in-transit">In-transit</span><span class="action-btn edit-btn" style="display: grid;">Edit</span></span></div><div class="order"><span class="order-id">321</span>
+        <span class="pickup">4 5345 343</span>
+        <span class="Destination">4 5343 343</span>
+        <span><span class="weight">5</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1000</span></span>
+        <span class="statuses"><span class="status in-transit">In-transit</span><span class="action-btn edit-btn" style="display: grid;">Edit</span></span></div><div class="order"><span class="order-id">353</span>
+        <span class="pickup">4 5435 324</span>
+        <span class="Destination">6 5356 353</span>
+        <span><span class="weight">3</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 600</span></span>
+        <span class="statuses"><span class="status delivered">Delivered</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">365</span>
+        <span class="pickup">4 5345 343</span>
+        <span class="Destination">4 5343 343</span>
+        <span><span class="weight">5</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1000</span></span>
+        <span class="statuses"><span class="status in-transit">In-transit</span><span class="action-btn edit-btn" style="display: grid;">Edit</span></span></div><div class="order"><span class="order-id">453</span>
+        <span class="pickup">4 5435 324</span>
+        <span class="Destination">6 5356 353</span>
+        <span><span class="weight">3</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 600</span></span>
+        <span class="statuses"><span class="status delivered">Delivered</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">495</span>
+        <span class="pickup">4 5435 324</span>
+        <span class="Destination">6 5356 353</span>
+        <span><span class="weight">3</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 600</span></span>
+        <span class="statuses"><span class="status delivered">Delivered</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">633</span>
+        <span class="pickup">5 6535 453</span>
+        <span class="Destination">8 5465 742</span>
+        <span><span class="weight">6</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1200</span></span>
+        <span class="statuses"><span class="status canceled">Canceled</span><span class="action-btn edit-btn">Edit</span></span></div><div class="order"><span class="order-id">808</span>
+        <span class="pickup">5 6535 453</span>
+        <span class="Destination">8 5465 742</span>
+        <span><span class="weight">6</span> Kgs</span>
+        <span><span>Kshs</span> <span class="price"> 1200</span></span>
+        <span class="statuses"><span class="status canceled">Canceled</span><span class="action-btn edit-btn">Edit</span></span></div></div>
+
+            </div>
+        </div>
+    </div>
+
+<!-- Code injected by live-server -->
+<script type="text/javascript">
+	// <![CDATA[  <-- For SVG support
+	if ('WebSocket' in window) {
+		(function () {
+			function refreshCSS() {
+				var sheets = [].slice.call(document.getElementsByTagName("link"));
+				var head = document.getElementsByTagName("head")[0];
+				for (var i = 0; i < sheets.length; ++i) {
+					var elem = sheets[i];
+					head.removeChild(elem);
+					var rel = elem.rel;
+					if (elem.href && typeof rel != "string" || rel.length == 0 || rel.toLowerCase() == "stylesheet") {
+						var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
+						elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
+					}
+					head.appendChild(elem);
+				}
+			}
+			var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
+			var address = protocol + window.location.host + window.location.pathname + '/ws';
+			var socket = new WebSocket(address);
+			socket.onmessage = function (msg) {
+				if (msg.data == 'reload') window.location.reload();
+				else if (msg.data == 'refreshcss') refreshCSS();
+			};
+			if (sessionStorage && !sessionStorage.getItem('IsThisFirstTime_Log_From_LiveServer')) {
+				console.log('Live reload enabled.');
+				sessionStorage.setItem('IsThisFirstTime_Log_From_LiveServer', true);
+			}
+		})();
+	}
+	else {
+		console.error('Upgrade your browser. This Browser is NOT supported WebSocket for Live-Reloading.');
+	}
+	// ]]>
+</script>
+<script src="Admin%20Dashboard_files/customerPages.js"></script>
+
+</body></html>

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -211,6 +211,10 @@ function viewOrder(user, mode) {
         singleOrder.classList.add('view-mode')
     }
 
+    if (mode == edit) {
+        singleOrder.classList.add('edit-mode');
+    }
+
     // Client view mode
     if (mode == edit && user == client) {
         editModeInputLabel = 'edit-input-label'
@@ -299,11 +303,12 @@ function viewOrder(user, mode) {
 // Listen to DOMContentLoaded event
 
 document.addEventListener('DOMContentLoaded', () => {
-    DisplayOrders(admin, all);
     if (pageTitle == 'Admin Dashboard') {
         AddEventListeners(admin);
+        DisplayOrders(admin, all);
     } else {
         AddEventListeners(client);
+        DisplayOrders(client, all);
     }
 
 

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -233,6 +233,7 @@ function viewOrder(user, mode) {
         <option value="intransit">In-transit</option>
         <option value="delivered">Delivered</option>
       </select></span></span> `;
+      singleOrder.classList.add('edit-mode');
 
     }
 
@@ -276,7 +277,7 @@ function viewOrder(user, mode) {
         editButton.style.display = 'inline'
 
         editButton.addEventListener('click', ()=>{
-            viewOrder(client, edit);
+        viewOrder(client, edit);
         });
     }
 

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -203,7 +203,7 @@ function viewOrder(user, mode) {
 
     var destLocationHtml = '<span id="">3-5334-533</span>';
     var currentLocationHtml = '<span class="content">Mai Mahiu</span>';
-    var statusHtml = '<span id="stts-color" class="in-transit">In-transit</span>';
+    var statusHtml = '<span><span id="stts-color" class="in-transit">In-transit</span></span>';
     var editModeInputLabel = '';
     var editModeInputLabelAdmin = '';
 
@@ -238,7 +238,7 @@ function viewOrder(user, mode) {
 
     // Both edit and view mode and both users 
     singleOrder.innerHTML =
-        `<span class="heading">Order Number: <span id="order-no">435</span><span class="edit-button">Edit</span></span>
+        `<span class="heading">Order Number: <span id="order-no">435</span><span class="edit-button invincible">Edit</span></span>
     <div id="delivery-stts" class="detail">
         <span class="label">Delivery status:</span>
         <span class="content split">${statusHtml}<span><span id="status" class="save-btn invincible">Save</span></span></span>
@@ -265,14 +265,39 @@ function viewOrder(user, mode) {
     </div>
     </div>`
     
+    const editButton = singleOrder.querySelector('.edit-button');
+    const statusText = singleOrder.querySelector('#stts-color').innerHTML
+    
+    // If the parcel hasnt been delivered
+    if(statusText == inTransit){
+        editButton.style.display = 'inline'
+    }
+
+    if (mode == edit){
+        editButton.style.display = 'none';
+    }
+
+    if (pageTitle == 'Admin Dashboard'){
+         editButton.addEventListener('click', ()=>{
+        viewOrder(admin, edit);
+    });
+    }else{
+        editButton.addEventListener('click', ()=>{
+            viewOrder(client, edit)
+    });
+    }
+   
     
     // Client edit mode
     if (mode == edit && user == client) {
-        // Get elementd
+        // Get elements
         const destInputDiv = singleOrder.querySelector('#dest-input');
         const saveDestBtn = singleOrder.querySelector('#dest-loc');
 
-        // Add event listeners
+
+    
+
+        // Add event listeners       
         destInputDiv.addEventListener('input', () => {
             saveDestBtn.style.display = 'grid';
         });

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -238,7 +238,7 @@ function viewOrder(user, mode) {
 
     // Both edit and view mode and both users 
     singleOrder.innerHTML =
-        `<span class="heading">Order Number: <span id="order-no">435</span></span>
+        `<span class="heading">Order Number: <span id="order-no">435</span><span class="edit-button">Edit</span></span>
     <div id="delivery-stts" class="detail">
         <span class="label">Delivery status:</span>
         <span class="content split">${statusHtml}<span><span id="status" class="save-btn invincible">Save</span></span></span>

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -265,26 +265,25 @@ function viewOrder(user, mode) {
     </div>
     </div>`
     
-    const editButton = singleOrder.querySelector('.edit-button');
-    const statusText = singleOrder.querySelector('#stts-color').innerHTML
     
-    // If the parcel hasnt been delivered
-    if(statusText == inTransit){
+
+    if (mode == view && pageTitle == 'Dashboard'){
+        const statusText = singleOrder.querySelector('#stts-color').innerHTML
+        const editButton = singleOrder.querySelector('.edit-button');
+
+        // If the parcel hasnt been delivered
+        if(statusText == inTransit){
         editButton.style.display = 'inline'
+
+        editButton.addEventListener('click', ()=>{
+            viewOrder(client, edit);
+        });
     }
+
 
     if (mode == edit){
         editButton.style.display = 'none';
     }
-
-    if (pageTitle == 'Admin Dashboard'){
-         editButton.addEventListener('click', ()=>{
-        viewOrder(admin, edit);
-    });
-    }else{
-        editButton.addEventListener('click', ()=>{
-            viewOrder(client, edit)
-    });
     }
    
     

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -64,6 +64,8 @@ function isEmpty(dict) {
 
 // Function to display order from
 function DisplayOrders(user, option) {
+    allOrdersDiv.style.marginTop = '0px';
+    ordersTitle.style.display = 'grid';
     currentOption = option;
     allOrdersDiv.innerHTML = '';
     var actionButton = '<span class="action-btn cancel-btn">Cancel</span>'

--- a/UI/static/js/customerPages.js
+++ b/UI/static/js/customerPages.js
@@ -66,7 +66,7 @@ function isEmpty(dict) {
 function DisplayOrders(user, option) {
     currentOption = option;
     allOrdersDiv.innerHTML = '';
-    var actionButton = '<span class="action-btn cancel-btn"><img src="static/img/cancel.png"></span>'
+    var actionButton = '<span class="action-btn cancel-btn">Cancel</span>'
     if (user == admin) {
         allOrders = allOrdersAdmin;
         actionButton = '<span class="action-btn edit-btn" >Edit</span>'


### PR DESCRIPTION
**What does this PR do?**
Edits all UI features that did not fit with the website style and fix display errors

**Description of Task to be completed?**
- A user now has access to edit button when viewing order details
- The order statistics color codes were not showing in the client dashboard
- Remove the tacky cancel buttons and replace them with suitable ones
- Add link to new order form on new order button

**How should this be manually tested?**
- clone repo into a local directory
- git clone --single-branch -b bg-fix-dashboard-UI 161697863https://github.com/ElMonstro/SendIT.git
- cd into the UI directory of the sendIT directory:
cd sendIT/UI
- open admin-dashboard.html and dashboard in your favorite browser
- Navigate through all the options
Any background context you want to provide?


**What are the relevant pivotal tracker stories?**

#161697863
**Screenshot**
__Before__
![image](https://user-images.githubusercontent.com/39956641/47958454-d8544280-dfdc-11e8-8add-4e46bba37457.png)

__After__
![image](https://user-images.githubusercontent.com/39956641/47958382-cfaf3c80-dfdb-11e8-8d28-58489cd1c3cf.png)

__Client edit order button__
__Before__
![image](https://user-images.githubusercontent.com/39956641/47958494-223d2880-dfdd-11e8-8a09-2449e42914e1.png)

__After__
![image](https://user-images.githubusercontent.com/39956641/47958399-1d2ba980-dfdc-11e8-9fc0-fbfb87c625eb.png)
